### PR TITLE
Fix file extension panics

### DIFF
--- a/lapix/src/util.rs
+++ b/lapix/src/util.rs
@@ -22,14 +22,21 @@ pub fn img_from_raw<IMG: Bitmap>(raw: image::RgbaImage) -> IMG {
 }
 
 /// Save an image to the specified file path
-pub fn save_image<IMG: Bitmap>(image: IMG, path: &str) {
-    let bytes = image.bytes();
+pub fn save_image<IMG: Bitmap>(bitmap: IMG, path: &str) {
+    use image::ImageFormat as Format;
+
+    let image_format =
+        Format::from_extension(std::path::Path::new(path).extension().unwrap_or_default())
+            .unwrap_or(Format::Png);
+
+    let bytes = bitmap.bytes();
 
     let img = image::RgbaImage::from_raw(
-        image.width() as u32,
-        image.height() as u32,
+        bitmap.width() as u32,
+        bitmap.height() as u32,
         bytes.to_owned(),
     )
     .expect("Failed to generate image from bytes");
-    img.save(path).expect("Failed to save image");
+    img.save_with_format(path, image_format)
+        .expect("Failed to save image");
 }

--- a/tarsila/src/gui/menu.rs
+++ b/tarsila/src/gui/menu.rs
@@ -55,7 +55,9 @@ impl MenuBar {
                     }
                     if ui.button("Save Project").clicked() {
                         ui.close_menu();
-                        let mut dialog = rfd::FileDialog::new();
+                        let mut dialog = rfd::FileDialog::new()
+                            .add_filter("Tarsila", &["tarsila"])
+                            .add_filter("All files", &["*"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {
                             dialog = dialog.set_directory(dir).set_file_name("project.tarsila");
@@ -69,7 +71,9 @@ impl MenuBar {
                     }
                     if ui.button("Load Project").clicked() {
                         ui.close_menu();
-                        let mut dialog = rfd::FileDialog::new();
+                        let mut dialog = rfd::FileDialog::new()
+                            .add_filter("Tarsila", &["tarsila"])
+                            .add_filter("All files", &["*"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {
                             dialog = dialog.set_directory(dir);
@@ -83,7 +87,9 @@ impl MenuBar {
                     }
                     if ui.button("Export Image").clicked() {
                         ui.close_menu();
-                        let mut dialog = rfd::FileDialog::new();
+                        let mut dialog = rfd::FileDialog::new()
+                            .add_filter("Image", &["png"])
+                            .add_filter("All files", &["*"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {
                             dialog = dialog.set_directory(dir);
@@ -96,7 +102,9 @@ impl MenuBar {
                     }
                     if ui.button("Import Image").clicked() {
                         ui.close_menu();
-                        let mut dialog = rfd::FileDialog::new();
+                        let mut dialog = rfd::FileDialog::new()
+                            .add_filter("Image", &["png"])
+                            .add_filter("All files", &["*"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {
                             dialog = dialog.set_directory(dir);

--- a/tarsila/src/gui/menu.rs
+++ b/tarsila/src/gui/menu.rs
@@ -56,7 +56,7 @@ impl MenuBar {
                     if ui.button("Save Project").clicked() {
                         ui.close_menu();
                         let mut dialog = rfd::FileDialog::new()
-                            .add_filter("Tarsila", &["tarsila"])
+                            .add_filter("Tarsila files", &["tarsila"])
                             .add_filter("All files", &["*"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {
@@ -72,7 +72,7 @@ impl MenuBar {
                     if ui.button("Load Project").clicked() {
                         ui.close_menu();
                         let mut dialog = rfd::FileDialog::new()
-                            .add_filter("Tarsila", &["tarsila"])
+                            .add_filter("Tarsila files", &["tarsila"])
                             .add_filter("All files", &["*"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {
@@ -88,7 +88,7 @@ impl MenuBar {
                     if ui.button("Export Image").clicked() {
                         ui.close_menu();
                         let mut dialog = rfd::FileDialog::new()
-                            .add_filter("Image", &["png"])
+                            .add_filter("PNG files", &["png"])
                             .add_filter("All files", &["*"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {
@@ -103,7 +103,7 @@ impl MenuBar {
                     if ui.button("Import Image").clicked() {
                         ui.close_menu();
                         let mut dialog = rfd::FileDialog::new()
-                            .add_filter("Image", &["png"])
+                            .add_filter("PNG files", &["png"])
                             .add_filter("All files", &["*"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {

--- a/tarsila/src/gui/menu.rs
+++ b/tarsila/src/gui/menu.rs
@@ -103,8 +103,8 @@ impl MenuBar {
                     if ui.button("Import Image").clicked() {
                         ui.close_menu();
                         let mut dialog = rfd::FileDialog::new()
-                            .add_filter("PNG files", &["png"])
-                            .add_filter("All files", &["*"]);
+                            .add_filter("All files", &["*"])
+                            .add_filter("PNG files", &["png"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {
                             dialog = dialog.set_directory(dir);

--- a/tarsila/src/gui/menu.rs
+++ b/tarsila/src/gui/menu.rs
@@ -89,6 +89,7 @@ impl MenuBar {
                         ui.close_menu();
                         let mut dialog = rfd::FileDialog::new()
                             .add_filter("PNG files", &["png"])
+                            .add_filter("JPEG files", &["jpg", "jpeg"])
                             .add_filter("All files", &["*"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {
@@ -104,7 +105,8 @@ impl MenuBar {
                         ui.close_menu();
                         let mut dialog = rfd::FileDialog::new()
                             .add_filter("All files", &["*"])
-                            .add_filter("PNG files", &["png"]);
+                            .add_filter("PNG files", &["png"])
+                            .add_filter("JPEG files", &["jpg", "jpeg"]);
 
                         if let Some(dir) = self.last_file.as_ref().and_then(|p| p.parent()) {
                             dialog = dialog.set_directory(dir);


### PR DESCRIPTION
Exporting images when there is no extension specified causes the program to panic. There are two fixes I put into place:

 - Added filters to file dialog so file type is populated by default
 - Modified `save_image` so the format defaults to PNG

This will also help when importing / exporting projects as there is now a file format specified by default (*.tarsila)