### PR TITLE
Save images using respective encoder

### DIFF
--- a/lapix/src/util.rs
+++ b/lapix/src/util.rs
@@ -1,4 +1,5 @@
 use crate::{color, Bitmap, Color};
+use image::{codecs, ImageEncoder, ImageFormat, ImageOutputFormat};
 
 /// Load an image from a file in the specified path
 pub fn load_img_from_file(path: &str) -> image::RgbaImage {
@@ -23,20 +24,25 @@ pub fn img_from_raw<IMG: Bitmap>(raw: image::RgbaImage) -> IMG {
 
 /// Save an image to the specified file path
 pub fn save_image<IMG: Bitmap>(bitmap: IMG, path: &str) {
-    use image::ImageFormat as Format;
-
-    let image_format =
-        Format::from_extension(std::path::Path::new(path).extension().unwrap_or_default())
-            .unwrap_or(Format::Png);
-
     let bytes = bitmap.bytes();
+    let width = bitmap.width() as u32;
+    let height = bitmap.height() as u32;
+    let color = image::ColorType::Rgba8;
 
-    let img = image::RgbaImage::from_raw(
-        bitmap.width() as u32,
-        bitmap.height() as u32,
-        bytes.to_owned(),
-    )
-    .expect("Failed to generate image from bytes");
-    img.save_with_format(path, image_format)
-        .expect("Failed to save image");
+    let file = std::fs::File::create(path).expect("Failed to create file from path");
+    let buffer = std::io::BufWriter::new(file);
+
+    let result = match ImageFormat::from_path(path)
+        .unwrap_or(ImageFormat::Png)
+        .into()
+    {
+        ImageOutputFormat::Png => {
+            codecs::png::PngEncoder::new(buffer).write_image(bytes, width, height, color)
+        }
+        ImageOutputFormat::Jpeg(_) => codecs::jpeg::JpegEncoder::new_with_quality(buffer, 100)
+            .write_image(bytes, width, height, color),
+        _ => panic!("File type is not supported"),
+    };
+
+    result.expect("Failed to save image");
 }


### PR DESCRIPTION
Fixes #5 

When saving an image using the `image` crate, the format is inferred via the path. A write buffer is created for the file and passed into the format's respective encoder, where the options can be modified. There is no direct way of modifying the encoder from the save function, so instead we create the encoders directly so we set the default JPEG compression quality to max.