### PR TITLE
Fix free images causing serious memory leak issues

### DIFF
--- a/tarsila/src/ui_state.rs
+++ b/tarsila/src/ui_state.rs
@@ -230,6 +230,11 @@ impl UiState {
 
         // TODO: most of this logic should be in some update method, not a draw one
         if let Some(img) = self.inner.free_image() {
+            // Macroquad's Texture2D is not automatically freed, so we need to free it manually,
+            // otherwise we risk exhausting video memory (and even system memory on some systems).
+            if let Some(tex) = &mut self.free_image_tex {
+                tex.delete();
+            }
             let tex = Texture2D::from_image(&img.texture.0);
             tex.set_filter(FilterMode::Nearest);
             self.free_image_tex = Some(tex);


### PR DESCRIPTION
Since macroquad [doesn't automatically free textures](https://github.com/not-fl3/macroquad/issues/421), we need to do it ourselves, otherwise we risk serious memory leak.
This causes eventual systemwide hang for me, as my video driver seems to be vulnerable to video memory leak, and eventually I run out of system memory as well.