### PR TITLE
WIP: Highlight active tool

### DIFF
--- a/tarsila/src/gui/mod.rs
+++ b/tarsila/src/gui/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Effect, UiEvent, UiState};
+use crate::{ui_state::LapixState, Effect, UiEvent, UiState};
 use lapix::{Position, Size, Tool};
 use macroquad::prelude::*;
 
@@ -78,7 +78,7 @@ impl Gui {
         self.status_bar.sync(params);
     }
 
-    pub fn update(&mut self) -> Vec<Effect> {
+    pub fn update(&mut self, lapix: &LapixState) -> Vec<Effect> {
         let mut events = Vec::new();
 
         let widget_color = egui::Color32::from_rgb(150, 150, 150);
@@ -111,7 +111,7 @@ impl Gui {
             let mut palette_events = self.palette.update(egui_ctx);
             events.append(&mut palette_events);
 
-            let mut toolbar_events = self.toolbar.update(egui_ctx);
+            let mut toolbar_events = self.toolbar.update(egui_ctx, lapix.selected_tool());
             events.append(&mut toolbar_events);
 
             let mut layers_events = self.layers_panel.update(egui_ctx);

--- a/tarsila/src/gui/mod.rs
+++ b/tarsila/src/gui/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ui_state::LapixState, Effect, UiEvent, UiState};
+use crate::{Effect, UiEvent, UiState};
 use lapix::{Position, Size, Tool};
 use macroquad::prelude::*;
 
@@ -42,6 +42,7 @@ pub struct Gui {
     status_bar: StatusBar,
     menu: MenuBar,
     mouse_on_canvas: bool,
+    selected_tool: Tool,
 }
 
 impl Gui {
@@ -54,6 +55,7 @@ impl Gui {
             status_bar: StatusBar::new(),
             menu: MenuBar::new(),
             mouse_on_canvas: false,
+            selected_tool: Tool::Brush,
         }
     }
 
@@ -61,6 +63,7 @@ impl Gui {
         self.mouse_on_canvas = params.is_on_canvas;
 
         self.toolbar.sync(params.main_color);
+        self.selected_tool = params.selected_tool;
         self.layers_panel.sync(
             params.num_layers,
             params.active_layer,
@@ -78,7 +81,7 @@ impl Gui {
         self.status_bar.sync(params);
     }
 
-    pub fn update(&mut self, lapix: &LapixState) -> Vec<Effect> {
+    pub fn update(&mut self) -> Vec<Effect> {
         let mut events = Vec::new();
 
         let widget_color = egui::Color32::from_rgb(150, 150, 150);
@@ -111,7 +114,7 @@ impl Gui {
             let mut palette_events = self.palette.update(egui_ctx);
             events.append(&mut palette_events);
 
-            let mut toolbar_events = self.toolbar.update(egui_ctx, lapix.selected_tool());
+            let mut toolbar_events = self.toolbar.update(egui_ctx, self.selected_tool);
             events.append(&mut toolbar_events);
 
             let mut layers_events = self.layers_panel.update(egui_ctx);

--- a/tarsila/src/gui/toolbar.rs
+++ b/tarsila/src/gui/toolbar.rs
@@ -111,25 +111,28 @@ impl ToolButton {
     }
 
     pub fn add_to_ui<F: FnMut()>(&mut self, ui: &mut egui::Ui, selected: bool, mut action: F) {
-        ui.scope(|ui| {
-            if selected {
-                ui.style_mut().visuals.widgets.inactive.weak_bg_fill =
-                    Color32::from_rgb(218, 218, 218);
-            }
-            let tooltip: &'static str = self.tooltip();
+        let tooltip: &'static str = self.tooltip();
 
-            let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
-                ui.ctx()
-                    .load_texture("", self.image.clone(), Default::default())
-            });
-            if ui
-                .add(egui::ImageButton::new(texture, texture.size_vec2()))
-                .on_hover_text(tooltip)
-                .clicked()
-            {
-                (action)();
-            }
+        let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
+            ui.ctx()
+                .load_texture("", self.image.clone(), Default::default())
         });
+        let prev_bg_fill = ui.style().visuals.widgets.inactive.weak_bg_fill;
+        // Highlight the currently selected tool.
+        //
+        // FIXME: Ui::scope destroys the toolbar's wrapping layout, so we're forced to temporarily
+        // set the style and then set back the old style manually after we're done.
+        if selected {
+            ui.style_mut().visuals.widgets.inactive.weak_bg_fill = Color32::from_rgb(218, 218, 218);
+        }
+        if ui
+            .add(egui::ImageButton::new(texture, texture.size_vec2()))
+            .on_hover_text(tooltip)
+            .clicked()
+        {
+            (action)();
+        }
+        ui.style_mut().visuals.widgets.inactive.weak_bg_fill = prev_bg_fill;
     }
 
     // TODO: the shortcut being hardcoded here is a problem since it's

--- a/tarsila/src/gui/toolbar.rs
+++ b/tarsila/src/gui/toolbar.rs
@@ -113,7 +113,8 @@ impl ToolButton {
     pub fn add_to_ui<F: FnMut()>(&mut self, ui: &mut egui::Ui, selected: bool, mut action: F) {
         ui.scope(|ui| {
             if selected {
-                ui.style_mut().visuals.widgets.inactive.weak_bg_fill = Color32::RED;
+                ui.style_mut().visuals.widgets.inactive.weak_bg_fill =
+                    Color32::from_rgb(218, 218, 218);
             }
             let tooltip: &'static str = self.tooltip();
 

--- a/tarsila/src/gui/toolbar.rs
+++ b/tarsila/src/gui/toolbar.rs
@@ -1,4 +1,5 @@
 use crate::{util, Effect, Resources};
+use egui::Color32;
 use lapix::{Event, Size, Tool};
 use macroquad::prelude::*;
 use std::collections::HashMap;
@@ -39,7 +40,7 @@ impl Toolbar {
         self.tools.get_mut(&tool)
     }
 
-    pub fn update(&mut self, egui_ctx: &egui::Context) -> Vec<Effect> {
+    pub fn update(&mut self, egui_ctx: &egui::Context, selected_tool: Tool) -> Vec<Effect> {
         let mut events = Vec::new();
 
         egui::Window::new("Toolbox")
@@ -75,7 +76,9 @@ impl Toolbar {
                     ui.set_max_width(160.);
                     for tool in TOOLS {
                         if let Some(btn) = self.get_mut(tool) {
-                            btn.add_to_ui(ui, || events.push(Event::SetTool(tool).into()));
+                            btn.add_to_ui(ui, selected_tool == tool, || {
+                                events.push(Event::SetTool(tool).into())
+                            });
                         }
                     }
                 });
@@ -107,20 +110,25 @@ impl ToolButton {
         }
     }
 
-    pub fn add_to_ui<F: FnMut()>(&mut self, ui: &mut egui::Ui, mut action: F) {
-        let tooltip: &'static str = self.tooltip();
+    pub fn add_to_ui<F: FnMut()>(&mut self, ui: &mut egui::Ui, selected: bool, mut action: F) {
+        ui.scope(|ui| {
+            if selected {
+                ui.style_mut().visuals.widgets.inactive.weak_bg_fill = Color32::RED;
+            }
+            let tooltip: &'static str = self.tooltip();
 
-        let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
-            ui.ctx()
-                .load_texture("", self.image.clone(), Default::default())
+            let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
+                ui.ctx()
+                    .load_texture("", self.image.clone(), Default::default())
+            });
+            if ui
+                .add(egui::ImageButton::new(texture, texture.size_vec2()))
+                .on_hover_text(tooltip)
+                .clicked()
+            {
+                (action)();
+            }
         });
-        if ui
-            .add(egui::ImageButton::new(texture, texture.size_vec2()))
-            .on_hover_text(tooltip)
-            .clicked()
-        {
-            (action)();
-        }
     }
 
     // TODO: the shortcut being hardcoded here is a problem since it's

--- a/tarsila/src/ui_state.rs
+++ b/tarsila/src/ui_state.rs
@@ -121,10 +121,8 @@ impl<'a> From<&'a UiState> for GuiSyncParams {
     }
 }
 
-pub type LapixState = State<WrappedImage>;
-
 pub struct UiState {
-    inner: LapixState,
+    inner: State<WrappedImage>,
     gui: Gui,
     camera: Position<f32>,
     canvas_pos: Position<f32>,
@@ -205,7 +203,7 @@ impl UiState {
         self.mouse_over_gui = false;
 
         self.gui.sync((&*self).into());
-        let fx = self.gui.update(&self.inner);
+        let fx = self.gui.update();
         self.process_fx(fx);
 
         let (x, y) = macroquad::prelude::mouse_position();

--- a/tarsila/src/ui_state.rs
+++ b/tarsila/src/ui_state.rs
@@ -121,8 +121,10 @@ impl<'a> From<&'a UiState> for GuiSyncParams {
     }
 }
 
+pub type LapixState = State<WrappedImage>;
+
 pub struct UiState {
-    inner: State<WrappedImage>,
+    inner: LapixState,
     gui: Gui,
     camera: Position<f32>,
     canvas_pos: Position<f32>,
@@ -203,7 +205,7 @@ impl UiState {
         self.mouse_over_gui = false;
 
         self.gui.sync((&*self).into());
-        let fx = self.gui.update();
+        let fx = self.gui.update(&self.inner);
         self.process_fx(fx);
 
         let (x, y) = macroquad::prelude::mouse_position();


### PR DESCRIPTION
This is a proof-of-concept feature of highlighting the active tool.
This allows the user to see what the current tool is, even if they are using the crosshair cursor.

In this screenshot, the eyedropper tool is active.
![image](https://user-images.githubusercontent.com/1521976/230614623-bd73d584-54c9-4ebb-9cac-505cd995d45c.png)
